### PR TITLE
Updated elgohr/Publish-Docker-Github-Action to a supported version (v5)

### DIFF
--- a/.github/workflows/Publish-docker-image.yml
+++ b/.github/workflows/Publish-docker-image.yml
@@ -13,7 +13,7 @@ jobs:
       - name: git checkout
         uses: actions/checkout@v3
       - name: Publish to Registry
-        uses: elgohr/Publish-Docker-Github-Action@v4
+        uses: elgohr/Publish-Docker-Github-Action@v5
         with:
           name: saikiran243275/githubactions:latest
           username: ${{ secrets.DOCKER_USERNAME }}

--- a/.github/workflows/apptemplate.yml
+++ b/.github/workflows/apptemplate.yml
@@ -30,7 +30,7 @@ jobs:
       - name: git checkout
         uses: actions/checkout@v3
       - name: Publish to Registry
-        uses: elgohr/Publish-Docker-Github-Action@v4
+        uses: elgohr/Publish-Docker-Github-Action@v5
         with:
           name: saikiran243275/githubactions:latest
           username: ${{ secrets.DOCKER_USERNAME }}


### PR DESCRIPTION
elgohr/Publish-Docker-Github-Action@master is not supported anymore